### PR TITLE
Update CppCoreGuidelines.md

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11843,7 +11843,10 @@ Instead, prefer to put the common code in a common helper function -- and make i
 
         template<class T>           // good, deduces whether T is const or non-const
         static auto get_bar_impl(T& t) -> decltype(t.get_bar())
-            { /* the complex logic around getting a possibly-const reference to my_bar */ }
+        { 
+            /* the complex logic around getting a possibly-const reference to my_bar, e.g.: */
+            return t.my_bar;
+        }
     };
 
 Note: Don't do large non-dependent work inside a template, which leads to code bloat. For example, a further improvement would be if all or part of `get_bar_impl` can be non-dependent and factored out into a common non-template function, for a potentially big reduction in code size.


### PR DESCRIPTION
Add an example return value in the example of ES.50 (dont cast away const) to showcase the use of argument "t".